### PR TITLE
Correct locale

### DIFF
--- a/http/preseed.cfg
+++ b/http/preseed.cfg
@@ -27,7 +27,7 @@ tasksel tasksel/first multiselect standard, ubuntu-server
 d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/layoutcode string us
 d-i keyboard-configuration/modelcode string pc105
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 
 # Create vagrant user account.
 d-i passwd/user-fullname string vagrant


### PR DESCRIPTION
Without this, if a desktop envrionment is loaded some applications (e.g. gnome-terminal) will not function as they cannot detect the correct locale to use